### PR TITLE
Make most methods const. Add method to get all pin values in one go.

### DIFF
--- a/api/mcp23017.h
+++ b/api/mcp23017.h
@@ -53,19 +53,19 @@ public:
 	 * @param polarity the polarity of the interrupt, true = active-high, false = active-low
 	 * @return PICO_ERROR_NONE or PICO_ERROR_GENERIC
 	 */
-	int setup(bool mirroring, bool polarity);
+	int setup(bool mirroring, bool polarity) const;
 
 	/**
 	 * Gets the first pin that has changed values within the last interrupt, not 100% reliable
 	 * @return pin 0-15 or PICO_ERROR_GENERIC
 	 */
-	int get_last_interrupt_pin();
+	int get_last_interrupt_pin() const;
 
 	/**
 	 * Gets the values of all interrupts for client code interrogation
 	 * @return values or PICO_ERROR_GENERIC
 	 */
-	int get_interrupt_values();
+	int get_interrupt_values() const;
 
 	/**
 	 * Stores the last input state in the class for later interrogation with get_input_pin_value
@@ -81,6 +81,12 @@ public:
 	bool get_input_pin_value(int pin) const;
 
 	/**
+	 * Returns all the pin states from the last update_input_values
+	 * @return the pin values
+	 */
+	uint16_t get_input_pin_values() const;
+
+	/**
 	 * Gets the address we were constructed to talk to
 	 * @return the address
 	 */
@@ -91,28 +97,28 @@ public:
 	 * @param direction '1' bits input, '0' bits output
 	 * @return PICO_ERROR_NONE or PICO_ERROR_GENERIC
 	 */
-	int set_io_direction(int direction);
+	int set_io_direction(int direction) const;
 
 	/**
 	 * Sets the pull-up resistors for the pins (100K)
 	 * @param direction '1' bits enable, '0' bits disable
 	 * @return PICO_ERROR_NONE or PICO_ERROR_GENERIC
 	 */
-	int set_pullup(int direction);
+	int set_pullup(int direction) const;
 
 	/**
 	 * Sets the interrupt control register
 	 * @param compare_to_reg '1' bits compare to default values, '0' bits compare to previous values
 	 * @return PICO_ERROR_NONE or PICO_ERROR_GENERIC
 	 */
-	int set_interrupt_type(int compare_to_reg);
+	int set_interrupt_type(int compare_to_reg) const;
 
 	/**
 	 * Sets the interrupt enabled register
 	 * @param enabled '1' bits enable, '0' bits disable
 	 * @return PICO_ERROR_NONE or PICO_ERROR_GENERIC
 	 */
-	int enable_interrupt(int enabled);
+	int enable_interrupt(int enabled) const;
 
 	/**
 	 * Sets all the output bits at once, also stores this as the internal state for later per pin manipulation with set_output_bit_for_pin
@@ -139,18 +145,18 @@ public:
 	 * Flushes the internal output state to the device
 	 * @return PICO_ERROR_NONE or PICO_ERROR_GENERIC
 	 */
-	int flush_output();
+	int flush_output() const;
 
 private:
-	int setup_bank_configuration(int reg, bool mirroring, bool polarity);
+	int setup_bank_configuration(int reg, bool mirroring, bool polarity) const;
 
-	int write_register(uint8_t reg, uint8_t value);
+	int write_register(uint8_t reg, uint8_t value) const;
 
-	int read_register(uint8_t reg);
+	int read_register(uint8_t reg) const;
 
-	int read_dual_registers(uint8_t reg);
+	int read_dual_registers(uint8_t reg) const;
 
-	int write_dual_registers(uint8_t reg, int value);
+	int write_dual_registers(uint8_t reg, int value) const;
 
 private:
 	i2c_inst_t *i2c;

--- a/source/mcp23017.cpp
+++ b/source/mcp23017.cpp
@@ -19,7 +19,7 @@ Mcp23017::Mcp23017(i2c_inst_t *_i2c, uint8_t _address) : i2c(_i2c), address(_add
 
 }
 
-int Mcp23017::write_register(uint8_t reg, uint8_t value) {
+int Mcp23017::write_register(uint8_t reg, uint8_t value) const {
 	uint8_t command[] = { reg, value };
 	int result = i2c_write_blocking(i2c, address, command, 2, false);
 	if (result == PICO_ERROR_GENERIC) {
@@ -28,7 +28,7 @@ int Mcp23017::write_register(uint8_t reg, uint8_t value) {
 	return PICO_ERROR_NONE;
 }
 
-int Mcp23017::read_register(uint8_t reg) {
+int Mcp23017::read_register(uint8_t reg) const {
 	uint8_t buffer = 0;
 	int result;
 	result = i2c_write_blocking(i2c, address,  &reg, 1, true);
@@ -45,7 +45,7 @@ int Mcp23017::read_register(uint8_t reg) {
 	return buffer;
 }
 
-int Mcp23017::write_dual_registers(uint8_t reg, int value) {
+int Mcp23017::write_dual_registers(uint8_t reg, int value) const {
 	uint8_t command[] = {
 			reg,
 			static_cast<uint8_t>(value & 0xff),
@@ -58,7 +58,7 @@ int Mcp23017::write_dual_registers(uint8_t reg, int value) {
 	return PICO_ERROR_NONE;
 }
 
-int Mcp23017::read_dual_registers(uint8_t reg) {
+int Mcp23017::read_dual_registers(uint8_t reg) const {
 	uint8_t buffer[2]{};
 	int result;
 	result = i2c_write_blocking(i2c, address,  &reg, 1, true);
@@ -75,7 +75,7 @@ int Mcp23017::read_dual_registers(uint8_t reg) {
 	return (buffer[1]<<8) + buffer[0];
 }
 
-int Mcp23017::setup(bool mirroring, bool polarity) {
+int Mcp23017::setup(bool mirroring, bool polarity) const {
 	int result;
 	result = setup_bank_configuration(MCP23017_IOCONA, mirroring, polarity);
 	if (result != 0)
@@ -85,7 +85,7 @@ int Mcp23017::setup(bool mirroring, bool polarity) {
 	return result;
 }
 
-int Mcp23017::setup_bank_configuration(int reg, bool mirroring, bool polarity) {
+int Mcp23017::setup_bank_configuration(int reg, bool mirroring, bool polarity) const {
 	int ioConValue = 0;
 	set_bit(ioConValue, MCP23017_IOCON_BANK_BIT, false);
 	set_bit(ioConValue, MCP23017_IOCON_MIRROR_BIT, mirroring);
@@ -97,7 +97,7 @@ int Mcp23017::setup_bank_configuration(int reg, bool mirroring, bool polarity) {
 	return write_register(reg, ioConValue);
 }
 
-int Mcp23017::get_last_interrupt_pin() {
+int Mcp23017::get_last_interrupt_pin() const {
 	int intFlag;
 
 	intFlag = read_dual_registers(MCP23017_INTFA); //also MCP23017_INTFB
@@ -113,7 +113,7 @@ int Mcp23017::get_last_interrupt_pin() {
 	return PICO_ERROR_GENERIC;
 }
 
-int Mcp23017::get_interrupt_values() {
+int Mcp23017::get_interrupt_values() const {
 	return read_dual_registers(MCP23017_INTCAPA); //will include MCP23017_INTCAPB
 }
 
@@ -130,23 +130,27 @@ bool Mcp23017::get_input_pin_value(int pin) const {
 	return is_bit_set(last_input, pin);
 }
 
+uint16_t Mcp23017::get_input_pin_values() const {
+	return last_input;
+}
+
 int Mcp23017::get_address() const {
 	return address;
 }
 
-int Mcp23017::set_io_direction(int direction) {
+int Mcp23017::set_io_direction(int direction) const {
 	return write_dual_registers(MCP23017_IODIRA, direction); //inc MCP23017_IODIRB
 }
 
-int Mcp23017::set_pullup(int direction) {
+int Mcp23017::set_pullup(int direction) const {
 	return write_dual_registers(MCP23017_GPPUA, direction); //inc MCP23017_GPPUB, direction >> 8);
 }
 
-int Mcp23017::set_interrupt_type(int compare_to_reg) {
+int Mcp23017::set_interrupt_type(int compare_to_reg) const {
 	return write_dual_registers(MCP23017_INTCONA, compare_to_reg); //inc MCP23017_INTCONB
 }
 
-int Mcp23017::enable_interrupt(int enabled) {
+int Mcp23017::enable_interrupt(int enabled) const {
 	return write_dual_registers(MCP23017_GPINTENA, enabled); //inc MCP23017_GPINTENB
 }
 
@@ -163,6 +167,6 @@ bool Mcp23017::get_output_bit_for_pin(int pin) const {
 	return is_bit_set(output, pin);
 }
 
-int Mcp23017::flush_output() {
+int Mcp23017::flush_output() const {
 	return write_dual_registers(MCP23017_GPIOA, output); //inc MCP23017_GPIOB
 }


### PR DESCRIPTION
Making methods const where applicable allows for the object to be passed by const reference or pointer most of the time.

Having access to all pin values in one variable was more convenient for my usage.